### PR TITLE
fix(scripts): seed-benchmark 跳过非题目数组的 json 文件

### DIFF
--- a/scripts/seed-benchmark.mjs
+++ b/scripts/seed-benchmark.mjs
@@ -22,7 +22,9 @@ if (files.length === 0) {
 const seen = new Set();
 const scenarios = [];
 for (const f of files) {
-  const arr = JSON.parse(fs.readFileSync(path.join(SCENARIOS_DIR, f), 'utf8'));
+  const parsed = JSON.parse(fs.readFileSync(path.join(SCENARIOS_DIR, f), 'utf8'));
+  if (!Array.isArray(parsed)) { console.log('  跳过 ' + f + '（非题目数组）'); continue; }
+  const arr = parsed;
   let added = 0;
   for (const s of arr) {
     if (seen.has(s.id)) continue;


### PR DESCRIPTION
## 问题

`scripts/seed-benchmark.mjs` 用 `readdirSync` 遍历 `data/scenarios/` 下**全部** `.json` 文件，但其中的 `benchmark-meta.json` 是元数据对象（`{version, count, dimensions, ...}`），不是题目数组。`for (const s of arr)` 直接抛：

```
TypeError: arr is not iterable
    at scripts/seed-benchmark.mjs:27:19
```

导致 clone 后按 README 执行 `node scripts/seed-benchmark.mjs` 必现崩溃，无法导入题库。

## 修复

解析后加 `Array.isArray` 检查：非数组文件打印「跳过」提示并 continue，不影响正常题目文件的导入与去重逻辑。

## 验证

- 修复前：`node scripts/seed-benchmark.mjs` 在读取 `benchmark-meta.json` 时崩溃；
- 修复后：输出 `跳过 benchmark-meta.json（非题目数组）`，随后 574 道 benchmark 题 + 45 道 cr2 补充题（去重后共 619 道）全部导入成功，失败 0。

环境：Node v24.20.0 / pnpm 11 / Linux。